### PR TITLE
Arista port-channel numbering

### DIFF
--- a/eos/access-interfaces.j2
+++ b/eos/access-interfaces.j2
@@ -75,15 +75,16 @@ interface {{ intf.name }}
 {% elif intf.ifclass == 'ACCESS_DOWNLINK' %}
  switchport
  switchport mode trunk
- {# The cli only allows for values between 1-2000 #}
- channel-group {{ intf.indexnum%2000 }} mode active
+ {# Arista port-channel numbering, use indexnum - 1 and no values higher than 1999 (meaning Ethernet1 = Port-channel1) #}
+ {% set po_num = (intf.indexnum-1)%2000 %}
+ channel-group {{ po_num }} mode active
 !
-interface Port-channel {{ intf.indexnum%2000 }}
+interface Port-channel {{ po_num }}
  description DOWNLINK
  port-channel lacp fallback static
  port-channel lacp fallback timeout 3
  {% if (mlag_peer is defined) and mlag_peer %}
-  mlag {{ intf.indexnum%2000 }}
+  mlag {{ po_num }}
  {% endif %}
 {% endif %}
 {% if (intf.data is defined) and intf.data %}

--- a/eos/dist-interfaces.j2
+++ b/eos/dist-interfaces.j2
@@ -29,9 +29,11 @@ interface {{ intf.name }}
  link-debounce time 20000 0
  switchport
  switchport mode trunk
- channel-group {{ intf.indexnum }} mode active
+ {# Arista port-channel numbering, use indexnum - 1 and no values higher than 1999 (meaning Ethernet1 = Port-channel1) #}
+ {% set po_num = (intf.indexnum-1)%2000 %}
+ channel-group {{ po_num }} mode active
 !
-interface Port-channel {{ intf.indexnum }}
+interface Port-channel {{ po_num }}
  {% if (intf.data is defined) and intf.data %}
   {% if (intf.data.description is defined) and intf.data.description %}
  description {{ intf.data.description }}


### PR DESCRIPTION
Use indexnum - 1 and no values higher than 1999 (meaning Ethernet1 = Port-channel1)